### PR TITLE
Remove release rule for chore prefix (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,17 +86,7 @@
 			"main"
 		],
 		"plugins": [
-			[
-				"@semantic-release/commit-analyzer",
-				{
-					"releaseRules": [
-						{
-							"type": "chore",
-							"release": "patch"
-						}
-					]
-				}
-			],
+			"@semantic-release/commit-analyzer",
 			"@semantic-release/release-notes-generator",
 			"@semantic-release/changelog",
 			"@semantic-release/npm",


### PR DESCRIPTION
This PR removes the specific semantic-release rule we had introduced to force a release on each release configuration change. This is not needed anymore.